### PR TITLE
Use rocm_check_target_ids if available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,19 +202,21 @@ if("${BACKEND}" STREQUAL "HIP")
     list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH} ${ROCM_PATH}/hip)
 
     # Set supported GPU Targets
-    find_package(ROCmCMakeBuildTools)
-    #include( ROCMSetupVersion )
-    include( ROCMCreatePackage )
-    message("-- ROCm Version Found: ${ROCM_PLATFORM_VERSION}")
-    set(GPU_TARGETS_ROCM_6.3 "gfx908;gfx90a;gfx942;gfx1030;gfx1031;gfx1032;gfx1100;gfx1101;gfx1102;gfx1200;gfx1201")
-    set(GPU_TARGETS_ROCM_6.4 "gfx908;gfx90a;gfx942;gfx950;gfx1030;gfx1031;gfx1032;gfx1100;gfx1101;gfx1102;gfx1200;gfx1201")
+    if(NOT GPU_TARGETS AND NOT AMDGPU_TARGETS)
+        find_package(ROCmCMakeBuildTools QUIET)
+        if(NOT ROCmCMakeBuildTools_FOUND)
+            find_package(ROCM QUIET)
+        endif()
+        include(ROCMCheckTargetIds OPTIONAL RESULT_VARIABLE HAS_ROCM_CHECK_TARGET_IDS)
 
-    if(${ROCM_PLATFORM_VERSION} GREATER_EQUAL 6.1.0 AND ${ROCM_PLATFORM_VERSION} LESS_EQUAL 6.3.0)
-        set(DEFAULT_GPU_TARGETS "${GPU_TARGETS_ROCM_6.3}")
-    elseif(${ROCM_PLATFORM_VERSION} GREATER_EQUAL 6.4.0)
-        set(DEFAULT_GPU_TARGETS "${GPU_TARGETS_ROCM_6.4}")
+        set(OPTIONAL_GPU_TARGETS "gfx942;gfx950;gfx1200;gfx1201")
+        if(HAS_ROCM_CHECK_TARGET_IDS)
+            rocm_check_target_ids(OPTIONAL_GPU_TARGETS_AVAILABLE TARGETS ${OPTIONAL_GPU_TARGETS})
+        else() # if we don't have rocm_check_target_ids, just assume the targets are available
+            set(OPTIONAL_GPU_TARGETS_AVAILABLE "${OPTIONAL_GPU_TARGETS}")
+        endif()
+        set(DEFAULT_GPU_TARGETS "gfx908;gfx90a;gfx1030;gfx1031;gfx1032;gfx1100;gfx1101;gfx1102;${OPTIONAL_GPU_TARGETS_AVAILABLE}")
     endif()
-
 
     # Set AMD GPU_TARGETS
     if((AMDGPU_TARGETS OR DEFINED ENV{AMDGPU_TARGETS}) AND (NOT GPU_TARGETS))


### PR DESCRIPTION
When setting the default GPU targets, this change causes rpp to use `rocm_check_target_ids` from rocm-cmake-build-tools (aka rocm-cmake), if it is available. Any targets from gfx942 and newer are checked with using a call to `check_cxx_compiler_flag` to verify that the compiler supports them, before they're added to the default GPU targets list.

This check is skipped if the user specifies a GPU target list, or if `rocm_check_target_ids` is not available at build time.